### PR TITLE
Sourcemaps

### DIFF
--- a/jade-backend.el
+++ b/jade-backend.el
@@ -138,6 +138,10 @@ prototype chain of the remote object.")
   "Get the source of the script for FRAME.
 Evaluate CALLBACK with the result.")
 
+(cl-defgeneric jade-backend-set-script-source (backend script-id source callback)
+  "Set the SOURCE of the script for SCRIPT-ID.
+Evaluate CALLBACK with the result.")
+
 (cl-defgeneric jade-backend-resume (backend &optional callback)
   "Resume the debugger and evaluate CALLBACK if non-nil.")
 

--- a/jade-interaction.el
+++ b/jade-interaction.el
@@ -42,6 +42,18 @@ evaluated."
   (jade-interaction--ensure-connection)
   (jade-eval (buffer-string)))
 
+(defun jade-set-script-source (script-id &optional bundle-buffer)
+  "Set script source for the buffer with SCRIPT-ID.
+Optionally take compiled source from BUNDLE-BUFFER."
+  (interactive "sScriptId: \nsBuffer: \n")
+  (jade-interaction--ensure-connection)
+  (with-current-buffer (or bundle-buffer (current-buffer))
+    (jade-backend-set-script-source (jade-backend)
+                                    script-id
+                                    (buffer-string)
+                                    (lambda ()
+                                      (message "Source set.")))))
+
 (defun jade-eval-last-node (arg)
   "Evaluate the node before point; print in the echo area.
 This is similar to `eval-last-sexp', but for JavaScript buffers.

--- a/jade-repl.el
+++ b/jade-repl.el
@@ -54,6 +54,11 @@
        (prog1 (progn . ,body)
          (set-marker ,marker ,pos)))))
 
+(defun jade-switch-to-repl-buffer ()
+  "Switch to the repl buffer."
+  (interactive)
+  (pop-to-buffer (jade-repl-get-buffer)))
+
 (defun jade-repl-get-buffer-create (connection)
   "Return a REPL buffer for CONNECTION.
 If no buffer exists, create one."

--- a/jade-repl.el
+++ b/jade-repl.el
@@ -252,7 +252,7 @@ optional."
 
 (defun jade-repl--emit-single-value-message (value level url line)
   "Emit a single VALUE.
-Used when there is only one value in the console message
+Used when there is only one VALUE in the console message
 e.g. console.log(1)."
   (jade-repl--emit-level level)
   (if (string= (map-elt value 'type) "string")
@@ -266,7 +266,7 @@ e.g. console.log(1)."
            (insert (jade-repl--format-url-line "\n" url line)))))
 
 (defun jade-repl--emit-multiple-values-message (values level url line)
-  "Emit values when there is more then one value in the console message
+  "Emit VALUES when there is more then one value in the console message
 e.g. console.log(1, 2, 3)."
   (jade-repl--emit-level level)
   (seq-do (lambda (value)
@@ -282,7 +282,13 @@ e.g. console.log(1, 2, 3)."
             (propertize (format "%s:%s" (file-name-nondirectory url) line)
                         'font-lock-face 'jade-link-face
                         'jade-action (lambda ()
-                                       (browse-url url))
+                                       (let ((buffer (get-buffer (file-name-nondirectory url))))
+                                         (if buffer
+                                             (progn
+                                               (switch-to-buffer buffer)
+                                               (goto-char 0)
+                                               (forward-line (1- line)))
+                                           (browse-url url))))
                         'rear-nonsticky '(font-lock-face jade-action)))))
 
 (defun jade-repl-next-input ()

--- a/jade-repl.el
+++ b/jade-repl.el
@@ -222,8 +222,9 @@ optional."
         ;; TODO: add an option to disable it
         ;; when we get an error, also display it in the echo area for
         ;; convenience
-        (when (jade-repl--message-level-error-p level)
-          (message text))))))
+        ;; (when (jade-repl--message-level-error-p level)
+        ;;   (message text))
+        ))))
 
 (defun jade-repl--emit-values (text values level url line)
   "Emit a console message values"


### PR DESCRIPTION
It's a proof of concept PR.
So I've started sourcemap support. I've implemented sourcemap for console messages.
Then I've made a `jade-set-script-source` command for interaction mode bound to `C-c C-k`.
Currently it works with plain js files without sourcemaps. It's obliviously wrong because interaction mode shouldn't depend on jade-webkit.
