### PR TITLE
Render boolean previews correctly

### DIFF
--- a/indium-v8-inspector.el
+++ b/indium-v8-inspector.el
@@ -447,7 +447,7 @@ RESULT should be a reference to a remote object."
                      value))
           (`string (format "\"%s\"" value))
           (`boolean (pcase value
-                      (`t "true")
+                      ((or t "true") "true")
                       (_ "false")))
           (_ (or value "null"))))))
 

--- a/indium-webkit.el
+++ b/indium-webkit.el
@@ -522,7 +522,7 @@ RESULT should be a reference to a remote object."
                      value))
           (`string (format "\"%s\"" value))
           (`boolean (pcase value
-                      (`t "true")
+                      ((or t "true") "true")
                       (_ "false")))
           (_ (or value "null"))))))
 


### PR DESCRIPTION
This fixes #51. I'm not sure if support for the symbol t should
be dropped, on the presumption that it could in some circumstances be
correct I left if in.

Sorry this is on master, but its a really small change.