### PR TITLE
Add `indium-interaction-eval-node-hook` to allow for eval hooks, e.g for overlays

### DIFF
--- a/indium-interaction.el
+++ b/indium-interaction.el
@@ -77,6 +77,10 @@ the current buffer."
       (indium-interaction--eval-node node)
     (user-error "No function at point")))
 
+(defvar indium-interaction-eval-node-hook nil
+  "Hooks to run after evaluating node before the point.")
+(add-hook 'indium-interaction-eval-node-hook #'indium-message)
+
 (defun indium-interaction--eval-node (node &optional print)
   "Evaluate the AST node NODE.
 If PRINT is non-nil, print the output into the current buffer."
@@ -89,7 +93,7 @@ If PRINT is non-nil, print the output into the current buffer."
                       (if print
                           (save-excursion
                             (insert description))
-                        (indium-message "%s" description))))))))
+                        (run-hook-with-args 'indium-interaction-eval-node-hook description))))))))
 
 (defun indium-reload ()
   "Reload the page."

--- a/indium-render.el
+++ b/indium-render.el
@@ -173,14 +173,17 @@ Otherwise, insert a newline."
   (let ((function (get-text-property (point) 'indium-action)))
     (funcall function)))
 
+(defun indium-fontify-js (args)
+  "Fontify ARGS as JavaScript."
+  (with-temp-buffer
+    (js-mode)
+    (insert (apply #'format args))
+    (font-lock-fontify-region (point-min) (point-max))
+    (buffer-string)))
+
 (defun indium-message (&rest args)
   "Display ARGS like `message', but fontified as JavaScript."
-  (let ((string (with-temp-buffer
-                  (js-mode)
-                  (insert (apply #'format args))
-                  (font-lock-fontify-region (point-min) (point-max))
-                  (buffer-string))))
-    (message "%s" string)))
+  (message "%s" (apply #'indium-fontify-js args)))
 
 (defun indium-render--truncate-string-to-newline (string)
   "Return STRING truncated before the first newline.


### PR DESCRIPTION
Inspired by http://endlessparentheses.com/eval-result-overlays-in-emacs-lisp.html, I wanted to try to make indium show evaled results inline with the code in a similar fasion to what [CIDER](https://cider.readthedocs.io/) does.

This pr does not add such functionality in indium, but shows how exposing a hook to handle results evaled with `indium-eval-last-node` can allow for extensions to accomplish this, along with keeping results shown in the minibuffer.

With such a hook in place, this is what it would take to show fontified, evaled results, inline with other code e.g. using cider's machinery

```elisp
(autoload 'cider--make-result-overlay "cider-overlays")
(defun t/overlay-indium (r)
  (cider--make-result-overlay (indium-fontify-js "%s" r) :where (point) :duration 'command))
(add-hook 'indium-interaction-eval-node-hook #'t/overlay-indium)
```

<img width="900" alt="image 2017-08-20 at 9 50 13 pm public" src="https://user-images.githubusercontent.com/118202/29497963-c803ebfa-85f2-11e7-83ed-17ea8b72cb69.png">

(Here I used `(setq indium-interaction-eval-node-hook (list #'t/overlay-indium))` to disable display of the results in the minibuffer.)

If you have other ideas for how to accomplish something similar I would love to hear them.