### PR TITLE
Initial webpack support

### DIFF
--- a/indium-chrome.el
+++ b/indium-chrome.el
@@ -106,11 +106,14 @@ Try a maximum of NUM-TRIES."
 
 (defun indium-chrome--get-tabs-data (host port callback)
   "Get the list of open tabs on HOST:PORT and evaluate CALLBACK with it."
-  (url-retrieve (format "http://%s:%s/json" host port)
-                (lambda (status)
-                  (funcall callback (if (eq :error (car status))
-                                        nil
-                                      (indium-chrome--read-tab-data))))))
+  (let ((buf (current-buffer)))
+    (url-retrieve (format "http://%s:%s/json" host port)
+                  (lambda (status)
+                    (let ((tabs (if (eq :error (car status))
+                                    nil
+                                  (indium-chrome--read-tab-data))))
+                      (setf (current-buffer) buf)
+                      (funcall callback tabs))))))
 
 (defun indium-chrome--connect-to-tab (tabs)
   "Connects to a tab in the list TABS.

--- a/indium-repl.el
+++ b/indium-repl.el
@@ -81,6 +81,18 @@
   "Return the name of the REPL buffer."
   "*JS REPL*")
 
+(defmacro indium-with-repl-buffer (&rest body)
+  (declare (indent defun))
+  (let ((buf (make-symbol "buf")))
+    `(when-let ((,buf (indium-repl-get-buffer)))
+       (with-current-buffer ,buf
+         ,@body))))
+
+(defun indium-repl-buffer-directory ()
+  "Return the directory of the REPL buffer."
+  (indium-with-repl-buffer
+    default-directory))
+
 (defun indium-repl-setup-buffer (buffer)
   "Setup the REPL BUFFER."
   (with-current-buffer buffer

--- a/indium-script.el
+++ b/indium-script.el
@@ -155,11 +155,9 @@ sourcemap."
 (defun indium-script-generated-location-at-point ()
   "Return a location for the position of POINT.
 If no location can be found, return nil."
-  (when-let ((file (buffer-file-name))
-             (path (file-truename file)))
-    (indium-script-generated-location
-     (make-indium-location :file path
-                           :line (1- (line-number-at-pos))))))
+  (indium-script-generated-location
+   (make-indium-location :file (buffer-file-name)
+                         :line (1- (line-number-at-pos)))))
 
 (defun indium-script-sourcemap (script)
   "Return the sourcemap object associated with SCRIPT.
@@ -208,8 +206,8 @@ If the sourcemap file cannot be downloaded either, return nil."
 Paths might be either absolute, or relative to the SCRIPT's
 directory.  To make things simpler with sourcemaps manipulation,
 make all source paths absolute."
-  (let ((sourcemap-root (file-truename (indium-script-root script)))
-        (webpack-root (file-truename (indium-workspace-root))))
+  (let ((sourcemap-root (indium-script-root script))
+        (webpack-root (indium-workspace-root)))
     (seq-do (lambda (entry)
               (when-let ((path (sourcemap-entry-source entry))
                          (expansion (indium-script--sourcemap-path path sourcemap-root webpack-root)))

--- a/indium-script.el
+++ b/indium-script.el
@@ -155,9 +155,11 @@ sourcemap."
 (defun indium-script-generated-location-at-point ()
   "Return a location for the position of POINT.
 If no location can be found, return nil."
-  (indium-script-generated-location
-   (make-indium-location :file buffer-file-name
-			 :line (1- (line-number-at-pos)))))
+  (when-let ((file (buffer-file-name))
+             (path (file-truename file)))
+    (indium-script-generated-location
+     (make-indium-location :file path
+                           :line (1- (line-number-at-pos))))))
 
 (defun indium-script-sourcemap (script)
   "Return the sourcemap object associated with SCRIPT.
@@ -177,20 +179,43 @@ If the sourcemap file cannot be downloaded either, return nil."
 	(indium-script--absolute-sourcemap-sources sourcemap script)))
     (indium-script-sourcemap-cache script)))
 
+(defconst indium-script--webpack-regexp "^webpack:///\\([^?]*\\)\\([?].*\\)?$")
+
+(defun indium-script--webpack-path-p (path)
+  (string-match-p indium-script--webpack-regexp path))
+
+(defun indium-script--webpack-path (path)
+  (replace-regexp-in-string indium-script--webpack-regexp
+                            "\\1"
+                            path))
+
+(defun indium-script--sourcemap-path (path sourcemap-root webpack-root)
+  (when path
+    (cond ((file-name-absolute-p path) path)
+          ((indium-script--webpack-path-p path)
+           (let ((path (indium-script--webpack-path path)))
+             (expand-file-name path webpack-root)))
+          (t (expand-file-name path sourcemap-root)))))
+
+(defun indium-script-root (script)
+  (or (when-let ((path (indium-script-get-file script t)))
+        (file-name-directory path))
+      (indium-workspace-root)))
+
 (defun indium-script--absolute-sourcemap-sources (sourcemap script)
   "Convert all relative source paths in SOURCEMAP to absolute ones.
 
 Paths might be either absolute, or relative to the SCRIPT's
 directory.  To make things simpler with sourcemaps manipulation,
 make all source paths absolute."
-  (seq-do (lambda (entry)
-	    (when-let ((path (sourcemap-entry-source entry)))
-	      (unless (file-name-absolute-p path)
-		(setf (sourcemap-entry-source entry)
-		      (expand-file-name path
-					(file-name-directory
-					 (indium-script-get-file script t)))))))
-	  sourcemap))
+  (let ((sourcemap-root (file-truename (indium-script-root script)))
+        (webpack-root (file-truename (indium-workspace-root))))
+    (seq-do (lambda (entry)
+              (when-let ((path (sourcemap-entry-source entry))
+                         (expansion (indium-script--sourcemap-path path sourcemap-root webpack-root)))
+                (unless (string= path expansion)
+                  (setf (sourcemap-entry-source entry) expansion))))
+            sourcemap)))
 
 (defun indium-script--sourcemap-file (script)
   "Return the local sourcemap file associated with SCRIPT.

--- a/indium-workspace.el
+++ b/indium-workspace.el
@@ -63,6 +63,7 @@
 (require 'indium-backend)
 
 (declare-function indium-repl-get-buffer "indium-repl.el")
+(declare-function indium-repl-buffer-directory "indium-repl.el")
 
 (defgroup indium-workspace nil
   "Indium workspace"
@@ -210,7 +211,8 @@ The path and query string of URL are stripped."
 
 (defun indium-workspace-root ()
   "Lookup the root workspace directory from the current buffer."
-  (indium-workspace-locate-dominating-file default-directory ".indium"))
+  (or (indium-repl-buffer-directory)
+      (indium-workspace-locate-dominating-file default-directory ".indium")))
 
 (defun indium-workspace-locate-dominating-file (file name)
   "Look up the directory hierarchy from FILE for a directory containing NAME.


### PR DESCRIPTION
This PR adds support for webpack configurations that emit source paths like `webpack:///./src/App.js`. The user must set their workspace root to be equal to the webpack root, **not** the static file directory. (Usually this is your project root path, i.e. wherever your application's top-level `package.json` file resides.)

Additionally, if a user has no `.indium` files in their project, this PR adds one convenience: When they go to select a workspace, the current buffer's directory appears in the suggestion list (along with all parent directories).

This allows you to open up e.g. `~/react/my-app/src/App.js`, run `indium-connect-to-chrome`, then see workspace suggestions like this:


```
/Users/shawn/react/my-app/src/
/Users/shawn/react/my-app/
/Users/shawn/react/
/Users/shawn/
<other workspace paths loaded from indium-workspaces.el>
/Users/
/
```

I find this very convenient since it lets me skip creating an `.indium` file altogether.

I've tested this on the default `create-react-app`, on a much more complicated webpack configuration, and on an app that doesn't use sourcemaps. All seem to work great.

I tried to solve #110 by using `file-truename` in certain places, but ran into issues setting breakpoints in files that don't use sourcemaps.