### PR TITLE
Avoid creating a new buffer if already exists.

### DIFF
--- a/indium-repl.el
+++ b/indium-repl.el
@@ -67,9 +67,9 @@
        (prog1 (progn . ,body)
          (set-marker ,marker ,pos)))))
 
-(defun indium-repl-buffer-create ()
+(defun indium-repl-get-buffer-create ()
   "Return a new REPL buffer."
-  (let* ((buf (generate-new-buffer (indium-repl-buffer-name))))
+  (let* ((buf (get-buffer-create (indium-repl-buffer-name))))
     (indium-repl-setup-buffer buf)
     buf))
 

--- a/indium-v8.el
+++ b/indium-v8.el
@@ -326,7 +326,7 @@ If NODEJS is non-nil, set an extra property in the connection.
 If WORKSPACE is non-nil, make it the workspace used for the connection."
   (setq indium-current-connection (indium-v8--make-connection ws url nodejs))
   (indium-v8--enable-tools)
-  (switch-to-buffer (indium-repl-buffer-create))
+  (switch-to-buffer (indium-repl-get-buffer-create))
   (when workspace (cd workspace))
   (indium-breakpoint-restore-breakpoints-in-all-buffers)
   (run-hooks 'indium-connection-open-hook))

--- a/test/unit/indium-chrome-test.el
+++ b/test/unit/indium-chrome-test.el
@@ -42,5 +42,10 @@
     (indium-chrome--connect-to-tab-with-url "file:///home/foo" '())
     (expect #'indium-workspace-read :not :to-have-been-called)))
 
+(describe "Regression test for GH issue #97"
+  (it "should not create multiple REPL buffers"
+    (let ((buf (indium-repl-get-buffer-create)))
+      (expect (indium-repl-get-buffer-create) :to-be buf))))
+
 (provide 'indium-chrome-test)
 ;;; indium-chrome-test.el ends here


### PR DESCRIPTION
This patch will try to recycle the buffer if already exists.

Fixes #97.