### PR TITLE
Always set breakpoint ids

### DIFF
--- a/indium-v8.el
+++ b/indium-v8.el
@@ -132,14 +132,13 @@ Evaluate CALLBACK on the filtered candidates."
               (locations (map-elt result 'locations))
 	      (location (seq--elt-safe locations 0))
               (line (map-elt location 'lineNumber)))
+	 (setf (indium-breakpoint-id breakpoint) id)
+	 (indium-current-connection-add-breakpoint breakpoint)
 	 (if line
-	     (progn
-	       (setf (indium-breakpoint-id breakpoint) id)
-	       (indium-current-connection-add-breakpoint breakpoint)
-	       (let ((script (indium-script-find-by-id
-			      (map-elt location 'scriptId)))
-		     (location (indium-v8--convert-from-v8-location location)))
-		 (indium-breakpoint-resolve id script location))
+	     (let ((script (indium-script-find-by-id
+			    (map-elt location 'scriptId)))
+		   (location (indium-v8--convert-from-v8-location location)))
+	       (indium-breakpoint-resolve id script location)
 	       (when callback
 		 (funcall callback breakpoint)))
 	   (message "Cannot get breakpoint location")))))))


### PR DESCRIPTION
* indium-v8.el (indium-backend-add-breakpoint): Set breakpoint ids even when
they cannot be resolved, and add them to the map of breakpoints in the current
connection.  This way breakpoints that are not yet resolved can still be
manipulated.