### PR TITLE
Add utility to connect to a Chrome instance.

### DIFF
--- a/indium-chrome.el
+++ b/indium-chrome.el
@@ -113,6 +113,15 @@ Try a maximum of NUM-TRIES."
           (port (read-from-minibuffer "Port: " (number-to-string indium-chrome-port))))
       (indium-chrome--get-tabs-data host port #'indium-chrome--connect-to-tab))))
 
+;;;###autoload
+(defun indium-chrome-connect-to-url (url &optional host port)
+  "Connect to a Chrome instance to a given tab URL.
+The default HOST is 'localhost' and PORT is '9229'."
+  (indium-chrome--get-tabs-data (or host "127.0.0.1")
+                                (or port "9229")
+                                (lambda (tabs)
+                                  (indium-chrome--connect-to-tab-with-url url tabs))))
+
 (defun indium-chrome--get-tabs-data (host port callback)
   "Get the list of open tabs on HOST:PORT and evaluate CALLBACK with it."
   (url-retrieve (format "http://%s:%s/json" host port)
@@ -120,6 +129,13 @@ Try a maximum of NUM-TRIES."
                   (funcall callback (if (eq :error (car status))
                                         nil
                                       (indium-chrome--read-tab-data))))))
+
+(defun indium-chrome--connect-to-url (host port url)
+  "Connect to a Chrome instance at HOST:PORT to a given tab URL."
+  (indium-chrome--get-tabs-data host
+                                port
+                                (lambda (tabs)
+                                  (indium-chrome--connect-to-tab-with-url url tabs))))
 
 (defun indium-chrome--connect-to-tab (tabs)
   "Connects to a tab in the list TABS.

--- a/sphinx-doc/setup.rst
+++ b/sphinx-doc/setup.rst
@@ -95,6 +95,19 @@ To connect to a tab, run from Emacs: ::
 
   M-x indium-connect-to-chrome
 
+Alternatively, you can connect to a local chrome programmatically using ``indium-chrome-connect-to-url``
+passing a ``Url`` to connect to.
+
+```
+(indium-chrome-connect-to-url URL)
+```
+
+``Host`` and ``Port`` are optional.
+
+```
+(indium-chrome-connect-to-url URL HOST PORT)
+```
+
 .. _local-files:
   
 Using local files when debugging

--- a/test/unit/indium-chrome-test.el
+++ b/test/unit/indium-chrome-test.el
@@ -130,6 +130,19 @@
     (indium-chrome--try-connect "foo" 1)
     (expect #'indium-chrome--connect-to-tab :to-have-been-called-with 'tabs)))
 
+(describe "Connecting to a Chrome instance"
+  (it "Should connect to a local Chrome instance."
+    (spy-on 'indium-chrome--connect-to-url)
+    (indium-chrome-connect-to-url "http://test.com")
+    (expect #'indium-chrome--connect-to-url
+            :to-have-been-called-with "127.0.0.1" "9229" "http://test.com"))
+
+  (it "Should connect to a Chrome instance at HOST:PORT to url."
+    (spy-on 'indium-chrome--connect-to-url)
+    (indium-chrome-connect-to-url "http://test.com" "127.0.0.1" "1")
+    (expect #'indium-chrome--connect-to-url
+            :to-have-been-called-with "127.0.0.1" "1" "http://test.com")))
+
 (describe "Regression test for GH issue #97"
   (it "should not create multiple REPL buffers"
     (let ((buf (indium-repl-get-buffer-create)))


### PR DESCRIPTION
Hi,

Add utility to connect to a chrome instance.
 
- `indium-chrome-connect-to-url`

Related issue:
- #134 