### PR TITLE
Explain that breakpoints halt the NodeJS event loop

### DIFF
--- a/sphinx-doc/repl.rst
+++ b/sphinx-doc/repl.rst
@@ -66,3 +66,48 @@ This means that while debugging, code execution will happen in the context of
 the current stack frame, and will be able to access local variables from the
 stack, etc.
 
+Using Promises or callbacks in the REPL buffer
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When your code is stopped at a breakpoint the `Node.js event loop
+<https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/>`_ is no
+longer running.
+
+If you use the REPL buffer while the debugger is stopped to invoke a Promise or
+callback then you will not get any response until you allow your code to
+continue. The debugger must continue to allow the event loop a chance to run and
+this may not always be possible at certain points in your code.
+
+Keeping the REPL around at the end of the NodeJS process
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 
+If your application file doesn't already have some sort of loop handling
+(perhaps its a selenium test file) then there is no way to halt at the end of
+the file to inspect the values of variables or perhaps invoke some experimental
+code during runtime.
+
+You will need to add your own debug REPL loop to the end of the application.
+Without this loop you will not be able to receive the responses of Promises or
+callbacks (see above) as the event loop will not run.
+
+This example is for selenium. It attaches a callback to run when all tests have
+been completed and runs our debugReplLoop. Remember you will need to close over
+any variables that you want to access from the REPL buffer or else they will not
+be in the context of the debugReplLoop.
+
+Now you can invoke code in the REPL buffer and continue the code to allow the
+event loop to process.
+
+  const debugReplLoop = () => {
+    const closeOverVariables = {
+      // Any variables you need access to in the REPL buffer
+    };
+
+    // stop and wait for continue force recompile
+    debugger;
+    setImmediate(debugReplLoop);
+  };
+
+  test.onFinish(() => {
+    setImmediate(debugReplLoop);
+  });


### PR DESCRIPTION
It was not obvious (it should be given Node is single threaded) that when the REPL is at a breakpoint invoking any Promise or callback functions will never allow them to run as the event loop is not running.

To allow the event loop to run you need to include your own debug repl loop in your application code.