### PR TITLE
Fix jumping to a location in debugger

### DIFF
--- a/server/adapters/cdp/helpers.js
+++ b/server/adapters/cdp/helpers.js
@@ -152,13 +152,13 @@ const convertCallFrame = async (
 	};
 };
 
-const resolveFileLocation = async (location, conf, scripts = []) => {
+const resolveFileLocation = async (location, conf, scripts = {}) => {
 	return await resolveFileLocationWithSourceMaps(location, conf, scripts)
 		|| resolveFileLocationWithScriptUrls(location, conf, scripts);
 };
 
 const resolveFileLocationWithSourceMaps = async ({ file, line }, conf, scripts) => {
-	for (let script of scripts) {
+	for (let script of Object.values(scripts)) {
 		let sourcemap = await getScriptSourceMap(script, conf);
 
 		if (sourcemap) {
@@ -180,7 +180,7 @@ const resolveFileLocationWithSourceMaps = async ({ file, line }, conf, scripts) 
 };
 
 const resolveFileLocationWithScriptUrls = ({ file, line }, conf, scripts) => {
-	for (let script of scripts) {
+	for (let script of Object.values(scripts)) {
 		if (script.url) {
 			let scriptFile = resolveUrl(script.url, conf);
 			if (file === scriptFile) {
@@ -196,8 +196,8 @@ const resolveFileLocationWithScriptUrls = ({ file, line }, conf, scripts) => {
 	return null;
 };
 
-const resolveScriptLocation = async (location, conf, scripts = []) => {
-	let script = scripts.find(s => s && s.id === location.scriptId);
+const resolveScriptLocation = async (location, conf, scripts = {}) => {
+	let script = Object.values(scripts).find(s => s.id === location.scriptId);
 	if (!script) {
 		return { ...location, url: "" };
 	}
@@ -212,13 +212,13 @@ const resolveScriptLocation = async (location, conf, scripts = []) => {
 	);
 };
 
-const resolveUrlLocation = async (location, conf, scripts = []) => {
+const resolveUrlLocation = async (location, conf, scripts = {}) => {
 	return await resolveUrlLocationWithSourceMaps(location, conf, scripts)
 		|| await resolveUrlLocationWithConfiguration(location, conf, scripts);
 };
 
 const resolveUrlLocationWithSourceMaps = async (location, conf, scripts) => {
-	let script = scripts.find(s => s.url === location.url);
+	let script = Object.values(scripts).find(s => s.url === location.url);
 
 	if (script && await getScriptSourceMap(script, conf)) {
 		let { source, line, column } = script.sourceMap.originalPositionFor(location);

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "indium",
-	"version": "3.3.0",
+	"version": "3.3.1",
 	"description": "Indium server",
 	"main": "index.js",
 	"scripts": {

--- a/server/spec/adapters/cdp/index-spec.js
+++ b/server/spec/adapters/cdp/index-spec.js
@@ -1,0 +1,19 @@
+const {
+	_test: {state, scriptAdded}
+} = require("../../../adapters/cdp/index");
+
+// Regression test for GitHub issue #175
+describe("Adding a new script with existing url", () => {
+	it("should not result in an undefined script", () => {
+		let id1 = "1";
+		let id2 = "2";
+		let url = "https://foo.bar";
+
+		scriptAdded({scriptId: id1, url});
+		scriptAdded({scriptId: id2, url});
+
+		let scripts = state.scripts;
+
+		expect(Object.keys(scripts)).toEqual([id2]);
+	});
+});


### PR DESCRIPTION
Fix github #175.

Previous implementation was sometimes considering `state.scripts` to
be an array and sometimes an object literal. This resulted in the
variable to contain `undefined` values after each call to
`scriptAdded`.