### PR TITLE
Add <scriptPathOverrides> feature.

### DIFF
--- a/server/helpers/workspace.js
+++ b/server/helpers/workspace.js
@@ -69,6 +69,19 @@ const resolveRoot = conf => {
 	return resolve(dir);
 };
 
+const locateScript = (pathname, conf) => {
+        let overrides = conf.scriptPathOverrides || {};
+
+        for (let pattern of Object.keys(overrides)) {
+                let regex = new RegExp(pattern);
+
+                if (pathname.match(regex)) {
+                        return pathname.replace(regex, overrides[pattern]);
+                }
+        }
+        return pathname;
+}
+
 const resolveUrl = (url, conf) => {
 	// In Node, script urls can be file paths.	The path doesn't
 	// always exist either, so also check for a protocol when parsed
@@ -86,7 +99,7 @@ const resolveUrl = (url, conf) => {
 		return pathname;
 	}
 
-	return resolve(`${root}/${pathname}`);
+	return resolve(`${root}/${locateScript(pathname, conf)}`);
 };
 
 const expandRoot = (path, root = "") => {

--- a/server/spec/helpers/workspace-spec.js
+++ b/server/spec/helpers/workspace-spec.js
@@ -220,4 +220,17 @@ describe("URL resolution", () => {
 
 		expect(resolveUrl(url, conf)).toEqual(url);
 	});
+
+        it("supports script path overrides", () => {
+		let conf = {
+			projectFile: "/home/user/projects/foo/.indium.json",
+                        "scriptPathOverrides": {
+                                "(/js/.*\\.js)/[0-9]+": "private$1"
+                        }
+		};
+
+                let url = "http://localhost:3000/js/app.js/1234567890";
+
+                expect(resolveUrl(url, conf)).toEqual("/home/user/projects/foo/private/js/app.js");
+        });
 });

--- a/sphinx-doc/debugger.rst
+++ b/sphinx-doc/debugger.rst
@@ -44,6 +44,29 @@ Overriding the ``sourceMapPathOverrides`` option will erase the default mapping.
 .. TIP:: If sourcemaps do not seem to work, you can see how Indium resolves
           sourcemap paths using ``M-x indium-list-sourcemap-sources``.
 
+.. _scriptpaths:
+
+Overriding script paths
+~~~~~~~~~~~~~~~~~~~~~~~
+
+If your application's script URLs don't correspond directly to where
+their source code is located, you can use ``scriptPathOverrides`` to
+tell Indium where to find the sources.  It maps regular expressions to
+Javascript substitution strings.
+
+For example, if your project root is ``/home/user/projects/foo/``, and
+the source code for http://localhost:3000/js/app.js/1234567890 is at
+``/home/user/projects/foo/private/js/app.js``, you might set
+``scriptPathOverrides`` to::
+
+   {
+     "(/js/.*\\.js)/[0-9]+": "private$1"
+   }
+
+This removes the trailing slash and digits, and it adds "private" to
+the beginning of the path below the project root.
+
+
 Blackboxing scripts
 -------------------
 

--- a/sphinx-doc/setup.rst
+++ b/sphinx-doc/setup.rst
@@ -48,8 +48,11 @@ this ``.indium.json`` file is placed, but it can be overridden with the ``root``
     ]
   }
 
-Custom sourcemap path overrides can be set with ``sourceMapPathOverrides``, see
-:ref:`sourcemaps` for mode information on sourcemaps and debugging.
+Custom script path overrides can be set with ``scriptPathOverrides``.  See
+:ref:`scriptpaths` for more information on script paths and debugging.
+
+Custom sourcemap path overrides can be set with ``sourceMapPathOverrides``.  See
+:ref:`sourcemaps` for more information on sourcemaps and debugging.
 
 .. _chrome_configuration:
 


### PR DESCRIPTION
Hello!  I've added a feature that allows the kind of mapping of scripts I mentioned in [issue #188](https://github.com/NicolasPetton/Indium/issues/188).  It's simple, and I've tried to match your coding, configuration naming, and documentation style everywhere.  I hope you will find it useful.