### PR TITLE
Fix how a breakpoint location is computed

### DIFF
--- a/indium-structs.el
+++ b/indium-structs.el
@@ -77,7 +77,7 @@
     (with-current-buffer buf
       (save-excursion
 	(goto-char (point-min))
-	(forward-char pos)
+	(forward-char (1- pos))
 	(back-to-indentation)
 	(indium-location-at-point)))))
 

--- a/test/unit/indium-breakpoint-test.el
+++ b/test/unit/indium-breakpoint-test.el
@@ -210,5 +210,14 @@
 	  (indium-breakpoint--unregister-all-breakpoints)
 	  (expect (indium-breakpoint-resolved brk) :to-be nil))))))
 
+(describe "Removing a breakpoint"
+  (it "should work when breakpoint is on point-max"
+    (with-js2-file
+      (goto-char (point-max))
+      (indium-breakpoint-add)
+      (expect (length (indium-breakpoint-breakpoints-at-point)) :to-be 1)
+      (indium-breakpoint-remove)
+      (expect (length (indium-breakpoint-breakpoints-at-point)) :to-be 0))))
+
 (provide 'indium-breakpoint-test)
 ;;; indium-breakpoint-test.el ends here

--- a/test/unit/indium-structs-test.el
+++ b/test/unit/indium-structs-test.el
@@ -78,7 +78,7 @@
   	(save-excursion
   	  (goto-char (point-max))
   	  (expect (indium-location-line (indium-breakpoint-location brk))
-  		  :to-equal 2))))))
+  		  :to-equal 1))))))
 
 (describe "Scopes"
   (it "Should be able to make scopes from alists"


### PR DESCRIPTION
* indium-structs.el (indium-breakpoint-location): Fix movement to
  return the proper location. Rationale: given that (point-min) is 1,
  after (goto-char (point-min)), 0 must be passed to forward-char
  instead of 1. This is particularly important if the breakpoint is
  at (point-max) because forward-char would raise an error.
* test/unit/indium-breakpoint-test.el: Add test.