### PR TITLE
Short-circuit on error when connecting to node

### DIFF
--- a/server/server/connection.js
+++ b/server/server/connection.js
@@ -56,7 +56,7 @@ const connectToNode = async (options = {}, { success, error }) => {
 			port: options.port || 9229 // The default port is 9229 in NodeJS.
 		}, { success, error });
 	} catch(e) {
-		error(e.message);
+		return error(e.message);
 	}
 	success("Connected to Node!");
 };


### PR DESCRIPTION
- This matches the behavior of chrome-type connections.
- It will stop emitting success messages when connection error has occurred.