### PR TITLE
Extract part of indium-client.el into a new library.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ dependencies-elisp:
 	--eval "(package-install 'js2-mode)" \
 	--eval "(package-install 'js2-refactor)" \
 	--eval "(package-install 'assess)" \
+	--eval "(package-install 'json-process-client)" \
 	--eval "(package-install 'exec-path-from-shell)"
 
 dependencies-javascript:

--- a/indium-structs.el
+++ b/indium-structs.el
@@ -40,8 +40,6 @@
 (require 'map)
 (require 'subr-x)
 
-(declare-function indium-client--next-id "indium-client.el")
-
 (cl-defstruct
     (indium-location (:constructor indium-location-create)
 		     (:constructor indium-location-at-point
@@ -64,7 +62,7 @@
 				   overlay
 				   id))
 	       (:copier nil))
-  (id (indium-client--next-id))
+  (id (indium-structs--next-breakpoint-id))
   (overlay nil)
   (resolved nil)
   (condition ""))
@@ -193,6 +191,14 @@ definitions."
 		       (indium-property-remote-object
 			property))
 		      "")))
+
+(defvar indium-structs--breakpoint-id 0
+  "A number that gets incremented by `indium-structs--next-breakpoint-id'.")
+
+(defun indium-structs--next-breakpoint-id ()
+  "Return a number, different at each call."
+  (cl-incf indium-structs--breakpoint-id)
+  indium-structs--breakpoint-id)
 
 (provide 'indium-structs)
 ;;; indium-structs.el ends here

--- a/indium.el
+++ b/indium.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/NicolasPetton/indium
 ;; Keywords: tools, javascript
 ;; Version: 2.1.1
-;; Package-Requires: ((emacs "25") (seq "2.16") (js2-mode "20140114") (js2-refactor "0.9.0") (company "0.9.0"))
+;; Package-Requires: ((emacs "25") (seq "2.16") (js2-mode "20140114") (js2-refactor "0.9.0") (company "0.9.0") (json-process-client "0.2.0"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/test/unit/indium-client-test.el
+++ b/test/unit/indium-client-test.el
@@ -25,45 +25,10 @@
 (require 'indium-client)
 
 (describe "Regression test for GitHub issue #163"
-  (it "should signal a user error when the indium executable cannot be found"
-    (let ((indium-client-executable ""))
-      (expect (indium-client-start (lambda ())) :to-throw
-	      'user-error '("Cannot find the indium executable.  Please run \"npm install -g indium\"")))))
-
-(describe "Reading server messages"
-  (it "should not change the buffer reading an incomplete message"
-    (with-temp-buffer
-      (insert "{foo")
-      (indium-client--handle-data (current-buffer))
-      (expect (buffer-string) :to-equal "{foo")))
-
-  (it "should call `indium-client--handle-message' when reading a complete message"
-    (spy-on #'indium-client--handle-message)
-    (with-temp-buffer
-      (insert "{\"foo\": 1}\n")
-      (indium-client--handle-data (current-buffer))
-      (expect #'indium-client--handle-message :to-have-been-called-with '((foo . 1)))))
-
-  (it "should remove the linefeed char when reading a complete message"
-    (spy-on #'indium-client--handle-message)
-    (with-temp-buffer
-      (insert "{\"foo\": 1}\n")
-      (indium-client--handle-data (current-buffer))
-      (expect (buffer-string) :to-equal "")))
-
-  (it "should remove all linefeed chars when reading multiple complete messages"
-    (spy-on #'indium-client--handle-message)
-    (with-temp-buffer
-      (insert "{\"foo\": 1}\n{\"bar\": 2}\n")
-      (indium-client--handle-data (current-buffer))
-      (expect (buffer-string) :to-equal "")))
-
-  (it "should remove all linefeed chars but keep incomplete messages"
-    (spy-on #'indium-client--handle-message)
-    (with-temp-buffer
-      (insert "{\"foo\": 1}\n{\"bar\": 2}\n{\"baz")
-      (indium-client--handle-data (current-buffer))
-      (expect (buffer-string) :to-equal "{\"baz"))))
+          (it "should signal a user error when the indium executable cannot be found"
+              (let ((indium-client-executable ""))
+                (expect (indium-client-start (lambda ())) :to-throw
+                        'user-error '("Cannot find the indium executable.  Please run \"npm install -g indium\"")))))
 
 (provide 'indium-client-test)
 ;;; indium-client-test.el ends here


### PR DESCRIPTION
This commit extracts part of indium-client.el into a reusable library (that I would like to use for a basecamp integration): [json-process-client.el](https://github.com/NicolasPetton/Indium/files/3365484/json-process-client.txt). If you agree with this extraction, I can take care of creating a repo (under `DamienCassou/`) or you can do it yourself (which would make more sense because you are the author). I will take care of creating a PR for MELPA unless you want to do it yourself.

* indium-client.el:
(indium-client--connection)
(indium-client--process)
(indium-client--callbacks): Remove to have `indium-client--application`
instead.
(indium-client--application): New variable to save the return value of
`json-process-client-start`.
(indium-client-start): Rewrite to call `json-process-client-start`.
(indium-client-stop): Rewrite to call `json-process-client-stop`.
(indium-client-send): Rewrite to call `json-process-client-send`.
(indium-client-process-live-p): Rewrite to call
`json-process-client-process-live-p`.
(indium-client--ensure-process)
(indium-client--start-server)
(indium-client--process-filter-function)
(indium-client--open-network-stream)
(indium-client--connection-sentinel)
(indium-client--connection-filter)
(indium-client--handle-data)
(indium-client--complete-message-p): Move to the new
`json-process-client` library.
(indium-client--handle-message): Add CALLBACK parameter.
(indium-client--handle-response): Call the CALLBACK parameter instead
of getting it from a global variable.