### PR TITLE
fix(test): use path.posix to allow cross platform testing

### DIFF
--- a/server/helpers/workspace.js
+++ b/server/helpers/workspace.js
@@ -1,5 +1,5 @@
 const { existsSync, readFileSync, readdirSync, statSync } = require("fs");
-const { join, resolve, basename, dirname } = require("path");
+const { join, resolve, basename, dirname } = require("path").posix;
 const { URL, parse } = require("url");
 
 const projectFilename = ".indium.json";


### PR DESCRIPTION
path.join resolves to Windows paths containing back slashes.

All the tests use Unix paths containing forward slashes.

Node doesn't care about using paths with forward slashes on Windows, but will
always return paths with back slashes. Using path.posix means the tests can be
cross platform.