### PR TITLE
Remove map-put from the code.

### DIFF
--- a/indium-breakpoint.el
+++ b/indium-breakpoint.el
@@ -40,7 +40,7 @@
 When CONDITION is non-nil, the breakpoint will be hit when
 CONDITION is true."
   (let* ((brk (indium-breakpoint-create :condition (or condition ""))))
-    (map-put indium-breakpoint--local-breakpoints brk (current-buffer))
+    (setf (map-elt indium-breakpoint--local-breakpoints brk nil #'equal) (current-buffer))
     (indium-breakpoint--add-overlay brk)
     (when (indium-client-process-live-p)
       (indium-client-add-breakpoint brk))))

--- a/indium-client.el
+++ b/indium-client.el
@@ -312,7 +312,7 @@ If has the following keys:
   url		url of the message origin
   line		line number in the resource that generated this message
   result 	object to be logged."
-  (map-put payload 'result (indium-remote-object-from-alist
+  (setf (map-elt payload 'result nil #'equal) (indium-remote-object-from-alist
 			    (map-elt payload 'result)))
   (run-hook-with-args 'indium-client-log-hook
 		      payload))


### PR DESCRIPTION
Emacs 27 is out, and has no map-put.

This PR to remove the macro from Indium.

https://github.com/NicolasPetton/Indium/issues/245