### PR TITLE
Fix missing debugger fringe indicators in daemon mode

### DIFF
--- a/indium-breakpoint.el
+++ b/indium-breakpoint.el
@@ -214,11 +214,11 @@ overlay."
       (when-let ((brk (overlay-get ov 'indium-breakpoint)))
 	(funcall fn brk ov)))))
 
-(when (and (fboundp 'define-fringe-bitmap) (display-images-p))
+(when (fboundp 'define-fringe-bitmap)
   (define-fringe-bitmap 'indium-breakpoint-resolved
     "\x3c\x7e\xff\xff\xff\xff\x7e\x3c")
   (define-fringe-bitmap 'indium-breakpoint-unresolved
-  "\x3c\x42\x81\x81\x81\x81\x42\x3c"))
+    "\x3c\x42\x81\x81\x81\x81\x42\x3c"))
 
 (provide 'indium-breakpoint)
 ;;; indium-breakpoint.el ends here


### PR DESCRIPTION
FYI, if Emacs starts in daemon mode then the call to `(display-graphic-p)` almost always returns `nil`; it only returns `t` if run in the context of a graphical client frame, which has to be manually created after the daemon finishes initialization.

Therefore, as currently written, an Emacs started in daemon mode that loads this package sometime during startup doesn't define the debugger breakpoint bitmaps.  So even if the user is using a graphical frame, nothing shows up in the fringe when adding breakpoints or breaking to them.

No harm results from taking out this `(display-graphic-p)` check.  Terminal / daemon Emacs already defines plenty of bitmaps with no ill effect (evaluate `fringe-bitmaps` in a terminal Emacs to see for yourself).