### PR TITLE
Send a CDP "disconnect" command when the NodeJS server expects it

### DIFF
--- a/indium-client.el
+++ b/indium-client.el
@@ -149,6 +149,14 @@ Once the client is connected, run the hook `indium-client-connected-hook'."
                       (lambda (&rest _)
 			(run-hooks 'indium-client-connected-hook))))
 
+(defun indium-client-disconnect (&optional callback)
+  "Disconnect from the runtime, but do not stop the indium process.
+
+When non-nil, evaluate CALLBACK with the result."
+  (indium-client-send `((type . "connection")
+                        (payload . ((action . "disconnect"))))
+                      callback))
+
 (defun indium-client-evaluate (expression &optional frame callback)
   "Evaluate EXPRESSION in the context of FRAME.
 

--- a/server/README.md
+++ b/server/README.md
@@ -116,6 +116,18 @@ Array of configurations.
 
 No payload.
 
+#### disconnect
+
+*Request payload:*
+
+| Key    | Type or value  | Description |
+|:-------|:---------------|:------------|
+| action | `"disconnect"` | Action type |
+
+*Successful response payload:*
+
+No payload.
+
 #### close
 
 *Request payload:*

--- a/server/server/connection.js
+++ b/server/server/connection.js
@@ -5,6 +5,8 @@ const connection = (data = {}, { success, error, stop }) => {
 	switch(data.action) {
 		case "connect":
 			return connect(data, { success, error });
+		case "disconnect":
+			return disconnect({ success, error });
 		case "close":
 			return stop();
 		default:
@@ -59,6 +61,15 @@ const connectToNode = async (options = {}, { success, error }) => {
 		return error(e.message);
 	}
 	success("Connected to Node!");
+};
+
+const disconnect = async ({ success, error }) => {
+	try {
+		await adapter.disconnect();
+	} catch(e) {
+		return error(e.message);
+	}
+	success("Disconnected");
 };
 
 module.exports = connection;


### PR DESCRIPTION
I'm developing a node project with one of those tools that restarts the server on every code change.  Indium as-is doesn't support this use case because node doesn't cleanly shut down until the debugging client disconnects.

Fortunately the CDP library already supports a disconnect command.  Here's a quick PR to implement the disconnect command in the elisp library and hook it up to the node process watchdog.

The updated node process filter is watching for the string "Waiting for the debugger to disconnect" because that's what I see on my machine with node v12.20.1.  I'd appreciate some help testing older versions to make sure that's a broad enough match.