### PR TITLE
Fix nodejs client isn't distinguished from chrome client

### DIFF
--- a/server/adapters/cdp/index.js
+++ b/server/adapters/cdp/index.js
@@ -56,7 +56,7 @@ const connect = async (options = {}) => {
 	state.configuration = options;
 	state.client = await doOrRetry(async () => await cdp(state.configuration));
 
-	state.isChrome = !!state.client.Network;
+	state.isChrome = !!state.client.Animation;
 
 	enableListeners();
 	enableDomains();


### PR DESCRIPTION
Current versions of nodejs (24.11) inspector have Network support.
So this check for chrome client isn't valid anymore.

`state.isChrome = !!state.client.Network;`

Probably changing to something like `state.isChrome = !!state.client.Animation;` should work as a temporary fix.